### PR TITLE
fix: disable contact form if no captcha token

### DIFF
--- a/frontend/components/ContactCard/index.tsx
+++ b/frontend/components/ContactCard/index.tsx
@@ -147,7 +147,7 @@ const ContactCard: React.FC = () => {
             uppercase={"true"}
             weight={700}
             type={"submit"}
-            disabled={status.submitting}
+            disabled={status.submitting || !recaptchaToken}
           >
             {!status.submitting ? (
               !status.submitted ? (


### PR DESCRIPTION
This pull request introduces a small improvement to the `ContactCard` component by updating the logic for disabling the submit button. The button is now disabled if the form is submitting or if the reCAPTCHA token is not present, which helps prevent accidental or invalid submissions.