### PR TITLE
feat: add button disabled styles

### DIFF
--- a/frontend/components/Buttons.ts
+++ b/frontend/components/Buttons.ts
@@ -1,9 +1,9 @@
-import styled, { css } from 'styled-components';
-import { media } from 'components/breakpoints';
-import { colors, GU } from 'components/theme';
+import styled, { css } from "styled-components";
+import { media } from "components/breakpoints";
+import { colors, GU } from "components/theme";
 
 interface IButton {
-  uppercase?: 'true';
+  uppercase?: "true";
   weight?: number;
 }
 
@@ -11,7 +11,7 @@ export const Button = styled.button<IButton>`
   background: ${colors.blue};
   border: none;
   color: ${colors.black};
-  font-family: 'Nunito Sans', sans-serif;
+  font-family: "Nunito Sans", sans-serif;
   font-size: 1.8rem;
   padding: ${GU * 2}px ${GU * 6}px;
   transition: all 0.3s ease;
@@ -22,16 +22,26 @@ export const Button = styled.button<IButton>`
     cursor: pointer;
   }
 
+  &:disabled {
+    background: ${colors.greyLight};
+    color: ${colors.grey};
+    cursor: not-allowed;
+  }
+
   ${media.xl`
     font-size: 2.2rem;
     padding: ${GU * 2}px ${GU * 10}px;
   `}
 
-  ${props => props.uppercase === 'true' && css`
-    text-transform: uppercase;
-  `}
+  ${(props) =>
+    props.uppercase === "true" &&
+    css`
+      text-transform: uppercase;
+    `}
 
-  ${props => props.weight && css`
-    font-weight: ${props.weight};
-  `}
+  ${(props) =>
+    props.weight &&
+    css`
+      font-weight: ${props.weight};
+    `}
 `;


### PR DESCRIPTION
This pull request introduces a minor update to the `Button` component in `frontend/components/Buttons.ts`, primarily improving its usability and code consistency. The most significant change is the addition of a disabled state style, ensuring that disabled buttons are visually distinct and non-interactive.

**Button usability improvements:**

* Added a disabled state to the `Button` component, which changes its background and text color and sets the cursor to `not-allowed` when the button is disabled.

**Code consistency updates:**

* Updated all string quotes from single to double quotes for consistency across imports and style definitions.